### PR TITLE
Fix game-suggestion table in dashboard. Used wrong id to find linked game.

### DIFF
--- a/app/Http/Livewire/table/GameSuggestionDashboardTable.php
+++ b/app/Http/Livewire/table/GameSuggestionDashboardTable.php
@@ -18,7 +18,7 @@ class GameSuggestionDashboardTable extends Table
     {
         return GameSuggestion::query()->where('party_id', $this->party->id)
             ->with(['party', 'user'])
-            ->join('games', 'games.id', '=' , 'game_suggestions.id');
+            ->join('games', 'games.id', '=' , 'game_suggestions.game_id');
     }
 
     /**


### PR DESCRIPTION
Fix suggestion-dashboard-table to use game_suggestion.game_id instead of game_suggestion.id to link to the suggested game.